### PR TITLE
renames worker config file and removes references to PKI

### DIFF
--- a/worker.hcl
+++ b/worker.hcl
@@ -11,7 +11,7 @@ listener "tcp" {
 }
 
 worker {
-  auth_storage_path = "/boundary/pki-worker1"
+  auth_storage_path = "/boundary/worker1"
   tags {
     type = ["worker", "vault"]
   }


### PR DESCRIPTION
This PR renames the `pki-worker.hcl` file to `worker.hcl`, and renames the worker to `worker1`.